### PR TITLE
feature(deployment): support google-dns with certbot

### DIFF
--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -254,7 +254,8 @@ services:
 
   # follows https://pentacent.medium.com/nginx-and-lets-encrypt-with-docker-in-less-than-5-minutes-b4b8a60d3a71
   certbot:
-    image: certbot/certbot
+    image: "${CERTBOT_IMAGE:-certbot/certbot}" # Allows overriding the image for specific certbot variants (e.g., certbot/dns-google)
+    network_mode: ${CERTBOT_NETWORK_MODE:-bridge} # Allows setting the network mode, defaulting to bridge (e.g., 'host' to allow gcp instances to access the compute metadata server for auth)
     restart: unless-stopped
     volumes:
       - ../data/certbot/conf:/etc/letsencrypt

--- a/deployment/docker_compose/init-letsencrypt.sh
+++ b/deployment/docker_compose/init-letsencrypt.sh
@@ -102,8 +102,12 @@ esac
 # Enable staging mode if needed
 if [ $staging != "0" ]; then staging_arg="--staging"; fi
 
+# Allows configuration of certbot auth method. Set default to webroot if not specified
+certbot_auth_args=${CERTBOT_AUTH_ARGS:-"--webroot -w /var/www/certbot"}
+
 $COMPOSE_CMD -f docker-compose.prod.yml run --name onyx-stack --rm --entrypoint "\
-  certbot certonly --webroot -w /var/www/certbot \
+  certbot certonly \
+    $certbot_auth_args \
     $staging_arg \
     $email_arg \
     $domain_args \


### PR DESCRIPTION
## Description

Add flexibility to deployment files to allow certbot to use google-dns as a verification method. I have implemented defaults that should functionally make this a no-op unless the environment is configured to utilize these changes.

## How Has This Been Tested?

Following the [Onyx guide for deploying on GCP](https://docs.onyx.app/production/gcp) I was stopped when trying to use the `init-letsencrypt.sh` script to configure SSL. Our self-hosted Onyx instance is on our private network and does not have a public IP making webroot verification by certbot not an option. I was able to work around this limitation by using google-dns verification.

1. Create GCP instance and DNS as described in [Onyx guide for deploying on GCP](https://docs.onyx.app/production/gcp). In our setup we omit a public IP for the instance.
2. Make the modifications in this PR to deployment files.
3. Outfit GCP instance's service account with [the necessary permissions](https://certbot-dns-google.readthedocs.io/en/stable/#providing-credentials)
4. Run the `.init-letsencrypt.sh` script with the following env vars defined:
    * CERTBOT_AUTH_ARGS="--dns-google"
    * CERTBOT_IMAGE="certbot/dns-google"
    * CERTBOT_NETWORK_MODE="host"
5. Certbot is able to fetch certs and Onyx server is reachable by https.

> Note: Running the certbot service in the docker-compose.prod.yml file with `network_mode: host` allows the certbot container to use the GCP instance's application default credentails to access the GCP metadata server for temporary auth. This does represent a small security implication as it bypasses docker's network isolation and gives the certbot container access to the host network. The alternative is to create a service account credential file, place it on the GCP instance, and then mount it into the docker container via a volume mount. As giving the certbot container access to the host network in order to use temporary auth via the metadata server poses a minimal risk, I evaluated that as a better option than creating a long lived service account key and storing it on the instance. 

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
